### PR TITLE
feat: ESP32 EMG WebSocket 단일 채널 통합 + 모드 기반 라우팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 venv/
 .venv/
-
+__pycache__/
+*.pyc

--- a/main.py
+++ b/main.py
@@ -1,21 +1,75 @@
+import asyncio
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+
 from routers.session_router import router as session_router
 from routers.calibration_router import router as calibration_router
 from routers.stream_router import router as stream_router
+from storage import device_mode_registry
+
+
+# -----------------------
+# Device lock 누수 방어 sweeper 설정
+# -----------------------
+# EMG 스트림이 이 시간(ms) 이상 끊긴 device 의 lock 을 강제 해제.
+# 너무 짧으면 잠깐 멈췄다가 재개할 때 lock 풀림 → 세션 끊김.
+# 너무 길면 진짜 누수 회복까지 오래 걸림.
+# 100Hz 이상 EMG 스트림 기준 30 초 비활성은 명백한 비정상.
+DEVICE_IDLE_THRESHOLD_MS = 30_000
+
+# sweeper 가 검사하는 주기(초).
+DEVICE_SWEEP_INTERVAL_S = 5
+
+
+async def _device_sweeper() -> None:
+    """
+    백그라운드에서 주기적으로 stale device lock 을 청소.
+    FastAPI lifespan 으로 등록되어 앱 시작 시 자동 실행, 종료 시 cancel 된다.
+    """
+    while True:
+        try:
+            await asyncio.sleep(DEVICE_SWEEP_INTERVAL_S)
+            cleared = device_mode_registry.sweep_stale(DEVICE_IDLE_THRESHOLD_MS)
+            if cleared:
+                print(f"[device-sweeper] cleared stale devices: {cleared}")
+        except asyncio.CancelledError:
+            # 정상 종료 신호
+            raise
+        except Exception as e:
+            # sweeper 가 죽으면 lock 누수 방어가 사라지므로 로그만 남기고 계속 돈다.
+            print(f"[device-sweeper] error (continuing): {e}")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    sweeper_task = asyncio.create_task(_device_sweeper())
+    try:
+        yield
+    finally:
+        sweeper_task.cancel()
+        try:
+            await sweeper_task
+        except asyncio.CancelledError:
+            pass
+
 
 app = FastAPI(
     title="NeuroMove AI Server",
     description="EMG-based intent inference AI server",
-    version="0.1.0"
+    version="0.1.0",
+    lifespan=lifespan,
 )
 
 app.include_router(session_router)
 app.include_router(calibration_router)
 app.include_router(stream_router)
 
+
 @app.get("/")
 def root():
     return {"message": "NeuroMove AI Server running"}
+
 
 @app.get("/health")
 def health_check():

--- a/routers/calibration_router.py
+++ b/routers/calibration_router.py
@@ -1,15 +1,12 @@
 from fastapi import APIRouter, HTTPException
 
 from schemas.calibration_schema import *
-from services.calibration_service import CalibrationService
-from storage import calibration_store, device_mode_registry
+from services import calibration_service
 
 router = APIRouter(
     prefix="/ai/calibration",
     tags=["calibration"],
 )
-
-calibration_service = CalibrationService(calibration_store, device_mode_registry)
 
 
 @router.get("/ping")

--- a/routers/calibration_router.py
+++ b/routers/calibration_router.py
@@ -1,34 +1,37 @@
 from fastapi import APIRouter, HTTPException
-from schemas.calibration_schema import *;
-from services.calibration_service import *;
-from storage.calibration_store import *;
+
+from schemas.calibration_schema import *
+from services.calibration_service import CalibrationService
+from storage import calibration_store, device_mode_registry
 
 router = APIRouter(
     prefix="/ai/calibration",
-    tags=["calibration"]
+    tags=["calibration"],
 )
 
+calibration_service = CalibrationService(calibration_store, device_mode_registry)
 
-calibration_store = CalibrationSessionStore()
-calibration_service = CalibrationService(calibration_store)
 
 @router.get("/ping")
 def calibration_ping():
     return {"message": "calibration router connected"}
 
-@router.post("/start",response_model=CalibrationStartResponse)
-def start_calibration(request:CalibrationStartRequest):
+
+@router.post("/start", response_model=CalibrationStartResponse)
+def start_calibration(request: CalibrationStartRequest):
     try:
         return calibration_service.start_calibration(request)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    
+
+
 @router.get("/status/{calibrationSessionId}", response_model=CalibrationStatusResponse)
-def get_calibration(calibrationSessionId:str):
+def get_calibration(calibrationSessionId: str):
     try:
         return calibration_service.get_calibration_status(calibrationSessionId)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
 
 @router.patch("/step", response_model=CalibrationStepUpdateResponse)
 def update_calibration_step(request: CalibrationStepUpdateRequest):
@@ -36,7 +39,6 @@ def update_calibration_step(request: CalibrationStepUpdateRequest):
         return calibration_service.update_calibration_step(request)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-
 
 
 @router.post("/finish", response_model=CalibrationFinishResponse)

--- a/routers/session_router.py
+++ b/routers/session_router.py
@@ -1,15 +1,15 @@
 from fastapi import APIRouter, HTTPException
+
 from schemas.session_schema import *
-from services.session_service import *
-from storage.session_store import *
+from services.session_service import SessionService
+from storage import session_store, device_mode_registry
 
 router = APIRouter(
     prefix="/ai/sessions",
-    tags=["sessions"]
+    tags=["sessions"],
 )
 
-session_store = SessionStore()
-session_service = SessionService(session_store)
+session_service = SessionService(session_store, device_mode_registry)
 
 
 @router.get("/ping")

--- a/routers/session_router.py
+++ b/routers/session_router.py
@@ -1,15 +1,12 @@
 from fastapi import APIRouter, HTTPException
 
 from schemas.session_schema import *
-from services.session_service import SessionService
-from storage import session_store, device_mode_registry
+from services import session_service
 
 router = APIRouter(
     prefix="/ai/sessions",
     tags=["sessions"],
 )
-
-session_service = SessionService(session_store, device_mode_registry)
 
 
 @router.get("/ping")

--- a/routers/stream_router.py
+++ b/routers/stream_router.py
@@ -1,62 +1,73 @@
-from fastapi import APIRouter,HTTPException,WebSocket,WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
-from schemas.stream_schema import *;
+
+from schemas.stream_schema import EmgWindowMessage, EmgWindowAck
 from services.stream_service import StreamService
+from storage import (
+    calibration_store,
+    session_store,
+    device_mode_registry,
+)
 
 router = APIRouter(
     prefix="/ai/stream",
-    tags=["stream"]
+    tags=["stream"],
 )
 
-stream_service = StreamService()
+stream_service = StreamService(
+    device_mode_registry=device_mode_registry,
+    calibration_store=calibration_store,
+    session_store=session_store,
+)
 
 
 @router.get("/ping")
 def stream_ping():
     return {"message": "stream router connected"}
 
+
 @router.websocket("/ws")
-async def websocket_handler(websocket:WebSocket):
+async def websocket_handler(websocket: WebSocket):
+    """
+    ESP32 ─ AI 서버 단일 EMG 스트림 채널.
+
+    - ESP32 는 calibration / session 구분 없이 EMG window 만 계속 전송한다.
+    - 서버는 deviceId 기준으로 DeviceModeRegistry 의 mode 를 보고
+        IDLE         → drop
+        CALIBRATION  → calibration_store 로 라우팅
+        SESSION      → session_store 로 라우팅
+      해서 처리한다.
+    """
     await websocket.accept()
     print("EMG websocket connected")
-    
+
     try:
         while True:
             raw = await websocket.receive_json()
-            
-            msg_type = raw.get("type")
 
             try:
-                if msg_type == "calibration_window":
-                    req = CalibrationWSRequest(**raw)
-                    res = stream_service.handle_calibration(req)
-
-                elif msg_type == "driving_window":
-                    req = DrivingWSRequest(**raw)
-                    res = stream_service.handle_driving(req)
-
-                else:
-                    raise ValueError("invalid type")
-
+                msg = EmgWindowMessage(**raw)
             except ValidationError as e:
                 await websocket.send_json({
-                    "type": msg_type,
+                    "type": "emg_window_ack",
                     "success": False,
                     "message": str(e),
-                    "data": None
+                    "data": None,
                 })
                 continue
 
+            try:
+                ack: EmgWindowAck = stream_service.handle_emg_window(msg)
             except Exception as e:
                 await websocket.send_json({
-                    "type": msg_type,
+                    "type": "emg_window_ack",
                     "success": False,
                     "message": str(e),
-                    "data": None
+                    "data": None,
                 })
                 continue
 
-            await websocket.send_json(res.model_dump(by_alias=True))
+            await websocket.send_json(ack.model_dump())
 
     except WebSocketDisconnect:
         print("WebSocket disconnected")

--- a/routers/stream_router.py
+++ b/routers/stream_router.py
@@ -43,11 +43,10 @@ async def websocket_handler(websocket: WebSocket):
 
     try:
         while True:
-            raw = await websocket.receive_json()
-
             try:
-                msg = EmgWindowMessage(**raw)
-            except ValidationError as e:
+                raw = await websocket.receive_json()
+                msg = EmgWindowMessage.model_validate(raw)
+            except (ValidationError, ValueError, TypeError) as e:
                 await websocket.send_json({
                     "type": "emg_window_ack",
                     "success": False,
@@ -67,7 +66,7 @@ async def websocket_handler(websocket: WebSocket):
                 })
                 continue
 
-            await websocket.send_json(ack.model_dump())
+            await websocket.send_json(ack.model_dump(by_alias=True))
 
     except WebSocketDisconnect:
         print("WebSocket disconnected")

--- a/routers/stream_router.py
+++ b/routers/stream_router.py
@@ -2,22 +2,11 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
 
 from schemas.stream_schema import EmgWindowMessage, EmgWindowAck
-from services.stream_service import StreamService
-from storage import (
-    calibration_store,
-    session_store,
-    device_mode_registry,
-)
+from services import stream_service
 
 router = APIRouter(
     prefix="/ai/stream",
     tags=["stream"],
-)
-
-stream_service = StreamService(
-    device_mode_registry=device_mode_registry,
-    calibration_store=calibration_store,
-    session_store=session_store,
 )
 
 
@@ -34,8 +23,8 @@ async def websocket_handler(websocket: WebSocket):
     - ESP32 는 calibration / session 구분 없이 EMG window 만 계속 전송한다.
     - 서버는 deviceId 기준으로 DeviceModeRegistry 의 mode 를 보고
         IDLE         → drop
-        CALIBRATION  → calibration_store 로 라우팅
-        SESSION      → session_store 로 라우팅
+        CALIBRATION  → CalibrationService.append_calibration_data
+        SESSION      → SessionService.append_window
       해서 처리한다.
     """
     await websocket.accept()

--- a/schemas/calibration_schema.py
+++ b/schemas/calibration_schema.py
@@ -23,16 +23,7 @@ class ChannelWindow(BaseModel):
     samples: List[int] = Field(..., description="Raw EMG samples for the channel")
 
 
-class CalibrationWindowRequest(BaseModel):
-    calibrationSessionId: str
-    deviceId: str
-    sequenceNumber: int
-    timestamp: int
-    samplingRate: int
-    windowSize: int
-    channels: List[ChannelWindow]
-
-#Calibration 측정 시작
+# Calibration 측정 시작
 class CalibrationStartRequest(BaseModel):
     calibrationSessionId: str
     userId: int
@@ -54,6 +45,7 @@ class CalibrationStartResponse(BaseModel):
     message: str
     data: CalibrationStartData
 
+
 # Calibration 단계 변경
 class CalibrationStepUpdateRequest(BaseModel):
     calibrationSessionId: str
@@ -70,7 +62,10 @@ class CalibrationStepUpdateResponse(BaseModel):
     message: str
     data: CalibrationStepUpdateData
 
-# EMG 센서에 측정되는 값 받기(esp32 보드)
+
+# EMG 센서에 측정되는 값 받기 (esp32 보드)
+# WebSocket 으로 들어온 EmgWindowMessage 를 StreamService 에서 이 형태로 변환해서
+# CalibrationService.append_calibration_data 로 넘겨준다.
 class CalibrationDataRequest(BaseModel):
     calibrationSessionId: str
     deviceId: str
@@ -80,16 +75,6 @@ class CalibrationDataRequest(BaseModel):
     windowSize: int
     channels: List[ChannelWindow]
 
-    
-class CalibrationDataResponseData(BaseModel):
-    calibrationSessionId: str
-    currentStep: CalibrationStep
-    stepWindowCounts: Dict[CalibrationStep, int]
-
-class CalibrationDataResponse(BaseModel):
-    success: bool
-    message: str
-    data: CalibrationDataResponseData
 
 # 백엔드한테 현재 진행 어느정도 됐는지 알리는 형식
 class CalibrationStatusData(BaseModel):
@@ -104,6 +89,7 @@ class CalibrationStatusResponse(BaseModel):
     success: bool
     message: str
     data: CalibrationStatusData
+
 
 # Calibration 종료 후 분석 결과
 class BaselineResult(BaseModel):

--- a/schemas/session_schema.py
+++ b/schemas/session_schema.py
@@ -1,8 +1,8 @@
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
-from schemas.calibration_schema import CalibrationResult
+from schemas.calibration_schema import CalibrationResult, ChannelWindow
 
 
 class SessionStatus(str, Enum):
@@ -60,3 +60,14 @@ class SessionEndResponse(BaseModel):
     success: bool
     message: str
     data: SessionEndData
+
+
+# WebSocket 으로 들어온 EmgWindowMessage 를 StreamService 에서 이 형태로 변환해서
+# SessionService.append_window 로 넘겨준다.
+# (CalibrationDataRequest 의 session 도메인 카운터파트)
+class SessionWindow(BaseModel):
+    sequenceNumber: int
+    timestamp: int
+    samplingRate: int
+    windowSize: int
+    channels: List[ChannelWindow]

--- a/schemas/stream_schema.py
+++ b/schemas/stream_schema.py
@@ -72,7 +72,7 @@ class EmgWindowMessage(BaseModel):
 
 class EmgWindowAckData(BaseModel):
     deviceId: str
-    mode: Literal["IDLE", "CALIBRATION", "SESSION"]
+    mode: DeviceMode
     activeId: Optional[str] = None
     acceptedSequenceNumber: int
     bufferedWindowCount: int

--- a/schemas/stream_schema.py
+++ b/schemas/stream_schema.py
@@ -1,6 +1,7 @@
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
+
 
 # 공통 채널
 class EMGChannel(BaseModel):
@@ -84,172 +85,16 @@ class EmgWindowAck(BaseModel):
     data: Optional[EmgWindowAckData] = None
 
 
-class EMGChannelData(BaseModel):
-    
-    # 채널 한 개의 EMG 샘플 데이터
-    # 예: channel_index=0, samples=[123, 118, 130, ...]
-    
-    channel_index: int = Field(..., ge=0, description="EMG 채널 인덱스",alias="channelIndex")
-    samples: List[int] = Field(
-        ...,
-        min_length=1,
-        description="해당 채널에서 수집된 raw EMG 샘플 배열"
-    )
-
-    # samples 값이 정상인지 추가 검사
-    @field_validator("samples")
-    @classmethod
-    def validate_samples(cls, v: List[float]) -> List[float]:
-
-        for sample in v:
-            if sample is None:
-                raise ValueError("samples must not contain null values")
-        return v
-
-
-class StreamRequestSchema(BaseModel):
-    
-    # ESP32 -> AI Server 로 들어오는 실시간 스트림 입력 schema
-    
-    model_config = ConfigDict(extra="forbid")
-
-    session_id: str = Field(
-        ...,
-        min_length=1,
-        max_length=100,
-        description="세션 식별자",
-        alias="sessionId"
-    )
-    sequence_number: int = Field(
-        ...,
-        ge=0,
-        description="스트림 패킷 순서 번호",
-        alias="sequenceNumber"
-    )
-    timestamp: int = Field(
-        ...,
-        ge=0,
-        description="클라이언트 기준 전송 시각 (epoch ms)",
-        alias="timestamp"
-    )
-    sampling_rate: int = Field(
-        ...,
-        gt=0,
-        le=5000,
-        description="EMG 샘플링 레이트(Hz)",
-        alias="samplingRate"
-    )
-    window_size: int = Field(
-        ...,
-        gt=0,
-        le=5000,
-        description="현재 요청에 포함된 샘플 수",
-        alias="windowSize"
-    )
-    channels: List[EMGChannelData] = Field(
-        ...,
-        min_length=1,
-        max_length=16,
-        description="채널별 EMG 데이터 목록",
-        alias="channels"
-    )
-
-    @field_validator("session_id")
-    @classmethod
-    def validate_session_id(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("session_id must not be blank")
-        return v
-
-    @field_validator("channels")
-    @classmethod
-    def validate_channels(cls, v: List[EMGChannelData]) -> List[EMGChannelData]:
-        if len(v) == 0:
-            raise ValueError("channels must not be empty")
-
-        # channels 안에는 각 채널이 한 번씩만 나와야 한다.
-        channel_indexes = [channel.channel_index for channel in v]
-        if len(channel_indexes) != len(set(channel_indexes)):
-            raise ValueError("channel_index must be unique")
-
-        sample_lengths = [len(channel.samples) for channel in v]
-        if len(set(sample_lengths)) != 1:
-            raise ValueError("all channels must have the same number of samples")
-
-        return v
-
-    @model_validator(mode="after")
-    def validate_window_matches_samples(self):
-        if not self.channels:
-            raise ValueError("channels must not be empty")
-
-        actual_size = len(self.channels[0].samples)
-        if self.window_size != actual_size:
-            raise ValueError(
-                f"window_size({self.window_size}) does not match "
-                f"actual sample size({actual_size})"
-            )
-        return self
-
 # =========================
-# (구) calibration_window / driving_window 분리 스키마는 제거됨.
-#  → ESP32 보드는 한 개이고, 동일 EMG 스트림을 모드에 따라 라우팅하는 구조로 통합.
-#  → EmgWindowMessage / EmgWindowAck 사용.
+# AI Server → Backend POST /api/ai/intent
 # =========================
-
-
-class InferenceResultSchema(BaseModel):
-    # AI 추론 결과 서버 내부 사용 용도
-    
-    predicted_intent: Literal[
-        "LEFT",
-        "RIGHT",
-        "FORWARD",
-        "BACKWARD",
-        "STOP",
-        "UNKNOWN"
-    ] = Field(..., description="예측된 사용자 의도")
-
-    confidence: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description="예측 confidence score"
-    )
-
-    feature_vector: Optional[List[float]] = Field(
-        default=None,
-        description="추론에 사용된 feature vector (디버깅/개발용)"
-    )
-
-    model_version: Optional[str] = Field(
-        default=None,
-        description="사용된 모델 버전"
-    )
-
-
-class StreamAckDataSchema(BaseModel):
-    session_id: str = Field(..., alias="sessionId")
-    device_id: str = Field(..., alias="deviceId")
-    accepted_sequence_number: int = Field(..., alias="acceptedSequenceNumber")
-    buffered_window_count: int = Field(..., alias="bufferedWindowCount")
-    inference_triggered: bool = Field(..., alias="inferenceTriggered")
-
-class StreamAckResponseSchema(BaseModel):
-    success: bool
-    message: str
-    data: StreamAckDataSchema | None = None
-    
-    
 class BackendInferenceSchema(BaseModel):
-    
-    # AI Server → Backend 전달용 추론 결과 schema
+    """추론 결과를 백엔드로 보낼 때 쓰는 request body."""
     model_config = ConfigDict(extra="forbid")
 
     sessionId: str = Field(..., min_length=1, max_length=100)
-    sequenceNumber : int
-    emgDeviceId : str
+    sequenceNumber: int
+    emgDeviceId: str
     timestamp: int = Field(..., ge=0)
 
     intent: Literal[
@@ -272,6 +117,7 @@ class BackendInferenceSchema(BaseModel):
         if not v:
             raise ValueError("sessionId must not be blank")
         return v
+
 
 class BackendCommandSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -300,6 +146,7 @@ class BackendInferenceResponseDataSchema(BaseModel):
 
 
 class BackendInferenceResponseSchema(BaseModel):
+    """백엔드의 POST /api/ai/intent 응답 파싱용."""
     model_config = ConfigDict(extra="forbid")
 
     success: bool

--- a/schemas/stream_schema.py
+++ b/schemas/stream_schema.py
@@ -4,8 +4,18 @@ from pydantic import BaseModel, Field, ConfigDict, field_validator, model_valida
 
 # 공통 채널
 class EMGChannel(BaseModel):
-    channelIndex: int
-    samples: List[int]
+    model_config = ConfigDict(extra="forbid")
+
+    channelIndex: int = Field(..., ge=0)
+    samples: List[int] = Field(..., min_length=1)
+
+    @field_validator("samples")
+    @classmethod
+    def validate_samples(cls, samples: List[int]) -> List[int]:
+        for sample in samples:
+            if sample is None:
+                raise ValueError("samples must not contain null values")
+        return samples
 
 
 # =========================
@@ -16,12 +26,47 @@ class EMGChannel(BaseModel):
 # - 서버의 DeviceModeRegistry 가 deviceId 기준으로 현재 활성 모드를 판단해
 #   calibration_store 또는 session_store 로 라우팅하고, 둘 다 아니면 무시한다.
 class EmgWindowMessage(BaseModel):
-    deviceId: str
-    sequenceNumber: int
-    timestamp: int
-    samplingRate: int
-    windowSize: int
-    channels: List[EMGChannel]
+    model_config = ConfigDict(extra="forbid")
+
+    deviceId: str = Field(..., min_length=1, max_length=100)
+    sequenceNumber: int = Field(..., ge=0)
+    timestamp: int = Field(..., ge=0)
+    samplingRate: int = Field(..., gt=0, le=5000)
+    windowSize: int = Field(..., gt=0, le=5000)
+    channels: List[EMGChannel] = Field(..., min_length=1, max_length=16)
+
+    @field_validator("deviceId")
+    @classmethod
+    def validate_device_id(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("deviceId must not be blank")
+        return value
+
+    @field_validator("channels")
+    @classmethod
+    def validate_channels(cls, channels: List[EMGChannel]) -> List[EMGChannel]:
+        channel_indexes = [channel.channelIndex for channel in channels]
+
+        if len(channel_indexes) != len(set(channel_indexes)):
+            raise ValueError("channelIndex must be unique")
+
+        sample_lengths = [len(channel.samples) for channel in channels]
+        if len(set(sample_lengths)) != 1:
+            raise ValueError("all channels must have the same number of samples")
+
+        return channels
+
+    @model_validator(mode="after")
+    def validate_window_matches_samples(self):
+        actual_size = len(self.channels[0].samples)
+
+        if self.windowSize != actual_size:
+            raise ValueError(
+                f"windowSize({self.windowSize}) does not match actual sample size({actual_size})"
+            )
+
+        return self
 
 
 class EmgWindowAckData(BaseModel):

--- a/schemas/stream_schema.py
+++ b/schemas/stream_schema.py
@@ -9,11 +9,34 @@ class EMGChannel(BaseModel):
 
 
 # =========================
-# BASE
+# 통합 EMG WebSocket 메시지
 # =========================
-class BaseWSRequest(BaseModel):
-    type: Literal["calibration_window", "driving_window"]
+# ESP32 한 보드에서 실시간으로 들어오는 EMG window 패킷.
+# - calibration / session 모드 구분은 ESP32 가 하지 않는다.
+# - 서버의 DeviceModeRegistry 가 deviceId 기준으로 현재 활성 모드를 판단해
+#   calibration_store 또는 session_store 로 라우팅하고, 둘 다 아니면 무시한다.
+class EmgWindowMessage(BaseModel):
+    deviceId: str
+    sequenceNumber: int
+    timestamp: int
+    samplingRate: int
+    windowSize: int
+    channels: List[EMGChannel]
 
+
+class EmgWindowAckData(BaseModel):
+    deviceId: str
+    mode: Literal["IDLE", "CALIBRATION", "SESSION"]
+    activeId: Optional[str] = None
+    acceptedSequenceNumber: int
+    bufferedWindowCount: int
+
+
+class EmgWindowAck(BaseModel):
+    type: Literal["emg_window_ack"] = "emg_window_ack"
+    success: bool
+    message: str
+    data: Optional[EmgWindowAckData] = None
 
 
 class EMGChannelData(BaseModel):
@@ -125,72 +148,11 @@ class StreamRequestSchema(BaseModel):
         return self
 
 # =========================
-# Calibration
+# (구) calibration_window / driving_window 분리 스키마는 제거됨.
+#  → ESP32 보드는 한 개이고, 동일 EMG 스트림을 모드에 따라 라우팅하는 구조로 통합.
+#  → EmgWindowMessage / EmgWindowAck 사용.
 # =========================
-class CalibrationWSRequest(BaseWSRequest):
-    type: Literal["calibration_window"]
 
-    calibrationSessionId: str
-    deviceId: str
-    sequenceNumber: int
-    timestamp: int
-    samplingRate: int
-    windowSize: int
-    channels: List[EMGChannel]
-
-
-class CalibrationWSAckData(BaseModel):
-    calibrationSessionId: str
-    deviceId: str
-    acceptedSequenceNumber: int
-    currentStep: str
-    bufferedWindowCount: int
-
-
-class CalibrationWSAck(BaseModel):
-    type: Literal["calibration_window_ack"]
-    success: bool
-    message: str
-    data: Optional[CalibrationWSAckData]
-
-
-# =========================
-# Driving
-# =========================
-class DrivingWSRequest(BaseWSRequest):
-    type: Literal["driving_window"]
-
-    sessionId: str
-    deviceId: str
-    sequenceNumber: int
-    timestamp: int
-    samplingRate: int
-    windowSize: int
-    channels: List[EMGChannel]
-
-
-class DrivingWSAckData(BaseModel):
-    sessionId: str
-    deviceId: str
-    acceptedSequenceNumber: int
-    bufferedWindowCount: int
-    inferenceTriggered: bool
-
-
-class DrivingWSAck(BaseModel):
-    type: Literal["driving_window_ack"]
-    success: bool
-    message: str
-    data: Optional[DrivingWSAckData]
-
-
-# =========================
-# Union
-# =========================
-WSRequestUnion = Union[
-    CalibrationWSRequest,
-    DrivingWSRequest
-]
 
 class InferenceResultSchema(BaseModel):
     # AI 추론 결과 서버 내부 사용 용도

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,41 @@
+"""
+services 패키지 - 도메인 서비스 싱글톤 모음.
+
+각 라우터는 여기서 동일 인스턴스를 import 해서 공유한다.
+StreamService 가 SessionService / CalibrationService 에 의존하기 때문에
+인스턴스를 한 곳에서 함께 만들어 주입해 두는 편이 안전하다.
+"""
+
+from storage import (
+    session_store,
+    calibration_store,
+    device_mode_registry,
+)
+from services.session_service import SessionService
+from services.calibration_service import CalibrationService
+from services.stream_service import StreamService
+
+session_service = SessionService(
+    session_store=session_store,
+    device_mode_registry=device_mode_registry,
+)
+
+calibration_service = CalibrationService(
+    calibration_store=calibration_store,
+    device_mode_registry=device_mode_registry,
+)
+
+stream_service = StreamService(
+    device_mode_registry=device_mode_registry,
+    calibration_service=calibration_service,
+    session_service=session_service,
+)
+
+__all__ = [
+    "session_service",
+    "calibration_service",
+    "stream_service",
+    "SessionService",
+    "CalibrationService",
+    "StreamService",
+]

--- a/services/calibration_service.py
+++ b/services/calibration_service.py
@@ -1,19 +1,31 @@
 from schemas.calibration_schema import *;
 from storage.calibration_store import *;
+from storage.device_mode_registry import DeviceModeRegistry
 import time
 from typing import Dict
 
 
 class CalibrationService:
-    def __init__(self, calibration_store: CalibrationSessionStore):
+    def __init__(
+        self,
+        calibration_store: CalibrationSessionStore,
+        device_mode_registry: DeviceModeRegistry,
+    ):
         self.calibration_store = calibration_store
+        self.device_mode_registry = device_mode_registry
 
     def start_calibration(self, request: CalibrationStartRequest,) -> CalibrationStartResponse:
         if self.calibration_store.exists(request.calibrationSessionId):
             raise ValueError("calibration session already exists")
 
+        # 같은 deviceId 가 이미 calibration / session 중이면 거절(요건 2: 동시 진행 금지)
+        self.device_mode_registry.set_calibration(
+            request.deviceId,
+            request.calibrationSessionId,
+        )
+
         started_at = int(time.time()*1000)
-        
+
         session = CalibrationSession(
             calibrationSessionId=request.calibrationSessionId,
             userId=request.userId,
@@ -170,6 +182,10 @@ class CalibrationService:
         )
         if completed_session is None:
             raise ValueError("failed to save calibration result")
+
+        # calibration 끝났으니 device 를 IDLE 로 풀어준다.
+        # → 같은 deviceId 로 session 시작 가능해짐
+        self.device_mode_registry.clear(completed_session.deviceId)
 
         return CalibrationFinishResponse(
             success=True,

--- a/services/calibration_service.py
+++ b/services/calibration_service.py
@@ -69,7 +69,7 @@ class CalibrationService:
                 canFinish = all(count > 0 for count in step_window_counts.values()) #기준 일단 임시로 정의
             ),
         )
-    
+
     def update_calibration_step(self,request: CalibrationStepUpdateRequest,) -> CalibrationStepUpdateResponse:
         session = self.calibration_store.get_session(request.calibrationSessionId)
         if session is None:
@@ -93,18 +93,31 @@ class CalibrationService:
                 currentStep=updated_session.currentStep,
             ),
         )
-    
-    def append_calibration_data(self,request: CalibrationDataRequest,) -> CalibrationDataResponse:
+
+    def append_calibration_data(
+        self,
+        request: CalibrationDataRequest,
+    ) -> CalibrationSession:
+        """
+        WebSocket 으로 들어온 EMG window 한 개를 calibration step buffer 에 누적.
+
+        StreamService 가 deviceMode == CALIBRATION 으로 라우팅한 후 호출하는,
+        calibration 도메인의 단일 ingest 엔트리포인트.
+
+        검증 실패 시 ValueError 를 던진다 (StreamService 가 catch 해 ack 로 변환).
+        """
         session = self.calibration_store.get_session(request.calibrationSessionId)
         if session is None:
             raise ValueError("calibration session not found")
 
         if session.status == CalibrationStatus.COMPLETED:
             raise ValueError("calibration session already completed")
-        
-        # 시퀀스 넘버가 이전보다 작거나 같으면 안됨 -> 증가만 하면 OK 
-        # TODO:
-        #실제 시스템은 “연속성 체크 + gap 감지” 로 변경하도록
+
+        if session.deviceId != request.deviceId:
+            raise ValueError("deviceId mismatch with active calibration session")
+
+        # 시퀀스 넘버가 이전보다 작거나 같으면 안됨 -> 증가만 하면 OK
+        # TODO: 실제 시스템은 "연속성 체크 + gap 감지" 로 변경
         if (
             session.lastSequenceNumber is not None
             and request.sequenceNumber <= session.lastSequenceNumber
@@ -118,22 +131,8 @@ class CalibrationService:
         if updated_session is None:
             raise ValueError("failed to append calibration data")
 
-        step_window_counts = self.calibration_store.get_step_window_counts(
-            request.calibrationSessionId
-        )
-        if step_window_counts is None:
-            raise ValueError("failed to load step window counts")
+        return updated_session
 
-        return CalibrationDataResponse(
-            success=True,
-            message="calibration data appended",
-            data=CalibrationDataResponseData(
-                calibrationSessionId=updated_session.calibrationSessionId,
-                currentStep=updated_session.currentStep,
-                stepWindowCounts=step_window_counts,
-            ),
-        )
-    
     def finish_calibration(self,request: CalibrationFinishRequest,) -> CalibrationFinishResponse:
         session = self.calibration_store.get_session(request.calibrationSessionId)
         if session is None:
@@ -198,7 +197,7 @@ class CalibrationService:
                 completedAt=completed_session.completedAt,
             ),
         )
-        
+
     def _check_can_finish(self, step_counts: Dict[CalibrationStep, int]) -> bool:
         required_count = 5
         return all(count >= required_count for count in step_counts.values())

--- a/services/session_service.py
+++ b/services/session_service.py
@@ -1,16 +1,29 @@
 import time
+from typing import Optional
 
 from schemas.session_schema import *;
 from storage.session_store import *;
+from storage.device_mode_registry import DeviceModeRegistry
 
 
 class SessionService:
-    def __init__(self, session_store: SessionStore):
+    def __init__(
+        self,
+        session_store: SessionStore,
+        device_mode_registry: DeviceModeRegistry,
+    ):
         self.session_store = session_store
+        self.device_mode_registry = device_mode_registry
 
     def start_session(self, request: SessionStartRequest,) -> SessionStartResponse:
         if self.session_store.exists(request.sessionId):
             raise ValueError("session already exists")
+
+        # 같은 deviceId 가 이미 calibration / 다른 session 중이면 거절
+        self.device_mode_registry.set_session(
+            request.deviceId,
+            request.sessionId,
+        )
 
         started_at = int(time.time() * 1000)
 
@@ -71,6 +84,9 @@ class SessionService:
         if ended_session is None:
             raise ValueError("failed to end session")
 
+        # session 끝났으니 device 를 IDLE 로 풀어준다.
+        self.device_mode_registry.clear(ended_session.deviceId)
+
         return SessionEndResponse(
             success=True,
             message="session ended",
@@ -79,4 +95,30 @@ class SessionService:
                 status=ended_session.status,
                 endedAt=ended_session.endedAt,
             ),
+        )
+
+    def append_window(
+        self,
+        session_id: str,
+        device_id: str,
+        sequence_number: int,
+    ) -> Optional[Session]:
+        """
+        WebSocket 으로 들어온 EMG window 한 개를 active session 에 누적.
+
+        - 추론(inference) 은 아직 미구현. 현재는 bufferedWindowCount 만 증가시킨다.
+        - 추후 inference_service 가 붙으면 여기에서 호출하게 된다. (TODO)
+        """
+        session = self.session_store.get_session(session_id)
+        if session is None:
+            return None
+        if session.status != SessionStatus.ACTIVE:
+            return None
+        if session.deviceId != device_id:
+            return None
+
+        # TODO: sequenceNumber 연속성/gap 감지
+        return self.session_store.increment_window_count(
+            session_id,
+            sequence_number,
         )

--- a/services/session_service.py
+++ b/services/session_service.py
@@ -1,5 +1,4 @@
 import time
-from typing import Optional
 
 from schemas.session_schema import *;
 from storage.session_store import *;
@@ -101,24 +100,43 @@ class SessionService:
         self,
         session_id: str,
         device_id: str,
-        sequence_number: int,
-    ) -> Optional[Session]:
+        window: SessionWindow,
+    ) -> Session:
         """
         WebSocket 으로 들어온 EMG window 한 개를 active session 에 누적.
 
-        - 추론(inference) 은 아직 미구현. 현재는 bufferedWindowCount 만 증가시킨다.
-        - 추후 inference_service 가 붙으면 여기에서 호출하게 된다. (TODO)
+        StreamService 가 deviceMode == SESSION 으로 라우팅한 후 호출하는,
+        세션 도메인의 단일 ingest 엔트리포인트.
+
+        - raw EMG 는 session_store._buffers (ring buffer) 에 저장되고,
+          추후 추론 파이프라인이 get_recent_windows() 로 꺼내서 사용한다.
+        - 검증 실패 시 ValueError (StreamService 가 catch 해 ack 로 변환).
+
+        TODO: 일정 buffer 누적 시점에서 추론 파이프라인을 트리거한다.
+              signal_processing -> feature -> inference -> backend POST /api/ai/intent
         """
         session = self.session_store.get_session(session_id)
         if session is None:
-            return None
+            raise ValueError("session not found")
         if session.status != SessionStatus.ACTIVE:
-            return None
+            raise ValueError("session is not active")
         if session.deviceId != device_id:
-            return None
+            raise ValueError("deviceId mismatch with active session")
+        if (
+            session.lastSequenceNumber is not None
+            and window.sequenceNumber <= session.lastSequenceNumber
+        ):
+            raise ValueError("invalid sequence number")
 
-        # TODO: sequenceNumber 연속성/gap 감지
-        return self.session_store.increment_window_count(
-            session_id,
-            sequence_number,
-        )
+        updated = self.session_store.append_window_data(session_id, window)
+        if updated is None:
+            raise ValueError("failed to append session window")
+
+        # TODO: 추론(inference) 트리거 위치
+        #   if self._should_trigger_inference(updated):
+        #       recent = self.session_store.get_recent_windows(session_id, N)
+        #       intent = self.inference_pipeline.run(updated, recent)
+        #       self.session_store.update_last_intent(session_id, intent.intent)
+        #       self.backend_client.send_intent(...)
+
+        return updated

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -62,7 +62,7 @@ class StreamService:
                 message="device idle, dropped",
                 data=EmgWindowAckData(
                     deviceId=msg.deviceId,
-                    mode="IDLE",
+                    mode=DeviceMode.IDLE,
                     activeId=None,
                     acceptedSequenceNumber=msg.sequenceNumber,
                     bufferedWindowCount=0,
@@ -182,6 +182,10 @@ class StreamService:
                 message=str(e),
                 data=None,
             )
+
+        # TODO: 추론(inference) 트리거 위치.
+        #   - 추후 별도 inference 파이프라인이 붙으면 여기서 호출.
+        #   - 현재 단계에서는 buffer 누적만 수행.
 
         return EmgWindowAck(
             success=True,

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -8,11 +8,16 @@ DeviceModeRegistry 의 mode 에 따라 calibration / session 으로 라우팅한
     ESP32 ──▶ /ai/stream/ws ──▶ StreamService.handle_emg_window
                                       │
                                       ├─ IDLE         → drop (요건 4)
-                                      ├─ CALIBRATION  → calibration_store.append_raw_data
-                                      └─ SESSION      → session_service.append_window
+                                      ├─ CALIBRATION  → CalibrationService.append_calibration_data
+                                      └─ SESSION      → SessionService.append_window
 
-이 서비스는 feature / inference / signal_processing 서비스를 호출하지 않는다.
-(추론 로직은 별도 모듈에서 추후 연결 예정 — 본 파일에서는 import 하지 않음.)
+이 서비스는 store 를 직접 호출하지 않는다. 도메인 검증 로직은 모두
+SessionService / CalibrationService 안에서 일어나고, StreamService 는
+- DeviceMode 라우팅
+- 패킷 → 도메인 request 변환
+- 활성 device 의 lastActiveAt 갱신 (lock 누수 방어)
+- 도메인 ValueError → ack 변환
+네 가지만 담당한다.
 """
 
 from typing import Optional
@@ -21,13 +26,14 @@ from schemas.calibration_schema import (
     CalibrationDataRequest,
     ChannelWindow,
 )
+from schemas.session_schema import SessionWindow
 from schemas.stream_schema import (
     EmgWindowMessage,
     EmgWindowAck,
     EmgWindowAckData,
 )
-from storage.calibration_store import CalibrationSessionStore
-from storage.session_store import SessionStore
+from services.calibration_service import CalibrationService
+from services.session_service import SessionService
 from storage.device_mode_registry import (
     DeviceModeRegistry,
     DeviceMode,
@@ -38,18 +44,19 @@ class StreamService:
     def __init__(
         self,
         device_mode_registry: DeviceModeRegistry,
-        calibration_store: CalibrationSessionStore,
-        session_store: SessionStore,
+        calibration_service: CalibrationService,
+        session_service: SessionService,
     ):
         self.device_mode_registry = device_mode_registry
-        self.calibration_store = calibration_store
-        self.session_store = session_store
+        self.calibration_service = calibration_service
+        self.session_service = session_service
 
     def handle_emg_window(self, msg: EmgWindowMessage) -> EmgWindowAck:
         state = self.device_mode_registry.get(msg.deviceId)
 
         if state.mode == DeviceMode.IDLE:
             # calibration 도, session 도 진행 중이 아님 → 무시 (요건 4)
+            # IDLE 인 device 는 lock 자체가 없으므로 touch 하지 않는다.
             return EmgWindowAck(
                 success=True,
                 message="device idle, dropped",
@@ -61,6 +68,10 @@ class StreamService:
                     bufferedWindowCount=0,
                 ),
             )
+
+        # 활성 device 가 살아있다는 신호 → lock 누수 방어 sweeper 가 안 풀도록 갱신.
+        # (검증 실패해도 일단 device 자체는 살아있으므로 touch 한다.)
+        self.device_mode_registry.touch(msg.deviceId)
 
         if state.mode == DeviceMode.CALIBRATION:
             return self._route_to_calibration(msg, state.activeId)
@@ -89,33 +100,6 @@ class StreamService:
                 data=None,
             )
 
-        session = self.calibration_store.get_session(calibration_session_id)
-        if session is None:
-            return EmgWindowAck(
-                success=False,
-                message="calibration session not found",
-                data=None,
-            )
-
-        if session.deviceId != msg.deviceId:
-            return EmgWindowAck(
-                success=False,
-                message="deviceId mismatch with active calibration session",
-                data=None,
-            )
-
-        # sequenceNumber 단조 증가 검증
-        # TODO: 추후 “연속성 + gap 감지” 로 업그레이드
-        if (
-            session.lastSequenceNumber is not None
-            and msg.sequenceNumber <= session.lastSequenceNumber
-        ):
-            return EmgWindowAck(
-                success=False,
-                message="invalid sequence number",
-                data=None,
-            )
-
         cal_request = CalibrationDataRequest(
             calibrationSessionId=calibration_session_id,
             deviceId=msg.deviceId,
@@ -132,14 +116,12 @@ class StreamService:
             ],
         )
 
-        updated = self.calibration_store.append_raw_data(
-            calibration_session_id,
-            cal_request,
-        )
-        if updated is None:
+        try:
+            updated = self.calibration_service.append_calibration_data(cal_request)
+        except ValueError as e:
             return EmgWindowAck(
                 success=False,
-                message="failed to append calibration data",
+                message=str(e),
                 data=None,
             )
 
@@ -174,46 +156,32 @@ class StreamService:
                 data=None,
             )
 
-        session = self.session_store.get_session(session_id)
-        if session is None:
-            return EmgWindowAck(
-                success=False,
-                message="session not found",
-                data=None,
-            )
-
-        if session.deviceId != msg.deviceId:
-            return EmgWindowAck(
-                success=False,
-                message="deviceId mismatch with active session",
-                data=None,
-            )
-
-        # sequenceNumber 단조 증가 검증
-        if (
-            session.lastSequenceNumber is not None
-            and msg.sequenceNumber <= session.lastSequenceNumber
-        ):
-            return EmgWindowAck(
-                success=False,
-                message="invalid sequence number",
-                data=None,
-            )
-
-        updated = self.session_store.increment_window_count(
-            session_id,
-            msg.sequenceNumber,
+        session_window = SessionWindow(
+            sequenceNumber=msg.sequenceNumber,
+            timestamp=msg.timestamp,
+            samplingRate=msg.samplingRate,
+            windowSize=msg.windowSize,
+            channels=[
+                ChannelWindow(
+                    channelIndex=ch.channelIndex,
+                    samples=ch.samples,
+                )
+                for ch in msg.channels
+            ],
         )
-        if updated is None:
+
+        try:
+            updated = self.session_service.append_window(
+                session_id=session_id,
+                device_id=msg.deviceId,
+                window=session_window,
+            )
+        except ValueError as e:
             return EmgWindowAck(
                 success=False,
-                message="failed to append session window",
+                message=str(e),
                 data=None,
             )
-
-        # TODO: 추론(inference) 트리거 위치.
-        #   - 추후 별도 inference 파이프라인이 붙으면 여기서 호출.
-        #   - 현재 단계에서는 buffer 누적만 수행.
 
         return EmgWindowAck(
             success=True,

--- a/services/stream_service.py
+++ b/services/stream_service.py
@@ -1,0 +1,228 @@
+"""
+StreamService
+
+ESP32 보드 한 개에서 WebSocket 으로 실시간 들어오는 EMG window 패킷을
+DeviceModeRegistry 의 mode 에 따라 calibration / session 으로 라우팅한다.
+
+흐름:
+    ESP32 ──▶ /ai/stream/ws ──▶ StreamService.handle_emg_window
+                                      │
+                                      ├─ IDLE         → drop (요건 4)
+                                      ├─ CALIBRATION  → calibration_store.append_raw_data
+                                      └─ SESSION      → session_service.append_window
+
+이 서비스는 feature / inference / signal_processing 서비스를 호출하지 않는다.
+(추론 로직은 별도 모듈에서 추후 연결 예정 — 본 파일에서는 import 하지 않음.)
+"""
+
+from typing import Optional
+
+from schemas.calibration_schema import (
+    CalibrationDataRequest,
+    ChannelWindow,
+)
+from schemas.stream_schema import (
+    EmgWindowMessage,
+    EmgWindowAck,
+    EmgWindowAckData,
+)
+from storage.calibration_store import CalibrationSessionStore
+from storage.session_store import SessionStore
+from storage.device_mode_registry import (
+    DeviceModeRegistry,
+    DeviceMode,
+)
+
+
+class StreamService:
+    def __init__(
+        self,
+        device_mode_registry: DeviceModeRegistry,
+        calibration_store: CalibrationSessionStore,
+        session_store: SessionStore,
+    ):
+        self.device_mode_registry = device_mode_registry
+        self.calibration_store = calibration_store
+        self.session_store = session_store
+
+    def handle_emg_window(self, msg: EmgWindowMessage) -> EmgWindowAck:
+        state = self.device_mode_registry.get(msg.deviceId)
+
+        if state.mode == DeviceMode.IDLE:
+            # calibration 도, session 도 진행 중이 아님 → 무시 (요건 4)
+            return EmgWindowAck(
+                success=True,
+                message="device idle, dropped",
+                data=EmgWindowAckData(
+                    deviceId=msg.deviceId,
+                    mode="IDLE",
+                    activeId=None,
+                    acceptedSequenceNumber=msg.sequenceNumber,
+                    bufferedWindowCount=0,
+                ),
+            )
+
+        if state.mode == DeviceMode.CALIBRATION:
+            return self._route_to_calibration(msg, state.activeId)
+
+        if state.mode == DeviceMode.SESSION:
+            return self._route_to_session(msg, state.activeId)
+
+        return EmgWindowAck(
+            success=False,
+            message=f"unknown device mode: {state.mode}",
+            data=None,
+        )
+
+    # -----------------------
+    # Calibration 라우팅
+    # -----------------------
+    def _route_to_calibration(
+        self,
+        msg: EmgWindowMessage,
+        calibration_session_id: Optional[str],
+    ) -> EmgWindowAck:
+        if calibration_session_id is None:
+            return EmgWindowAck(
+                success=False,
+                message="calibration mode but no active calibrationSessionId",
+                data=None,
+            )
+
+        session = self.calibration_store.get_session(calibration_session_id)
+        if session is None:
+            return EmgWindowAck(
+                success=False,
+                message="calibration session not found",
+                data=None,
+            )
+
+        if session.deviceId != msg.deviceId:
+            return EmgWindowAck(
+                success=False,
+                message="deviceId mismatch with active calibration session",
+                data=None,
+            )
+
+        # sequenceNumber 단조 증가 검증
+        # TODO: 추후 “연속성 + gap 감지” 로 업그레이드
+        if (
+            session.lastSequenceNumber is not None
+            and msg.sequenceNumber <= session.lastSequenceNumber
+        ):
+            return EmgWindowAck(
+                success=False,
+                message="invalid sequence number",
+                data=None,
+            )
+
+        cal_request = CalibrationDataRequest(
+            calibrationSessionId=calibration_session_id,
+            deviceId=msg.deviceId,
+            sequenceNumber=msg.sequenceNumber,
+            timestamp=msg.timestamp,
+            samplingRate=msg.samplingRate,
+            windowSize=msg.windowSize,
+            channels=[
+                ChannelWindow(
+                    channelIndex=ch.channelIndex,
+                    samples=ch.samples,
+                )
+                for ch in msg.channels
+            ],
+        )
+
+        updated = self.calibration_store.append_raw_data(
+            calibration_session_id,
+            cal_request,
+        )
+        if updated is None:
+            return EmgWindowAck(
+                success=False,
+                message="failed to append calibration data",
+                data=None,
+            )
+
+        buffered = sum(
+            len(buf) for buf in updated.stepBuffers.values()
+        )
+
+        return EmgWindowAck(
+            success=True,
+            message="calibration window appended",
+            data=EmgWindowAckData(
+                deviceId=msg.deviceId,
+                mode="CALIBRATION",
+                activeId=calibration_session_id,
+                acceptedSequenceNumber=msg.sequenceNumber,
+                bufferedWindowCount=buffered,
+            ),
+        )
+
+    # -----------------------
+    # Session(driving) 라우팅
+    # -----------------------
+    def _route_to_session(
+        self,
+        msg: EmgWindowMessage,
+        session_id: Optional[str],
+    ) -> EmgWindowAck:
+        if session_id is None:
+            return EmgWindowAck(
+                success=False,
+                message="session mode but no active sessionId",
+                data=None,
+            )
+
+        session = self.session_store.get_session(session_id)
+        if session is None:
+            return EmgWindowAck(
+                success=False,
+                message="session not found",
+                data=None,
+            )
+
+        if session.deviceId != msg.deviceId:
+            return EmgWindowAck(
+                success=False,
+                message="deviceId mismatch with active session",
+                data=None,
+            )
+
+        # sequenceNumber 단조 증가 검증
+        if (
+            session.lastSequenceNumber is not None
+            and msg.sequenceNumber <= session.lastSequenceNumber
+        ):
+            return EmgWindowAck(
+                success=False,
+                message="invalid sequence number",
+                data=None,
+            )
+
+        updated = self.session_store.increment_window_count(
+            session_id,
+            msg.sequenceNumber,
+        )
+        if updated is None:
+            return EmgWindowAck(
+                success=False,
+                message="failed to append session window",
+                data=None,
+            )
+
+        # TODO: 추론(inference) 트리거 위치.
+        #   - 추후 별도 inference 파이프라인이 붙으면 여기서 호출.
+        #   - 현재 단계에서는 buffer 누적만 수행.
+
+        return EmgWindowAck(
+            success=True,
+            message="session window appended",
+            data=EmgWindowAckData(
+                deviceId=msg.deviceId,
+                mode="SESSION",
+                activeId=session_id,
+                acceptedSequenceNumber=msg.sequenceNumber,
+                bufferedWindowCount=updated.bufferedWindowCount,
+            ),
+        )

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,0 +1,24 @@
+"""
+storage 패키지 - 프로세스 단위 싱글톤 store / registry 모음.
+
+각 라우터는 여기서 동일 인스턴스를 import 해서 공유한다.
+(stream_router, calibration_router, session_router 가 같은 store 를 봐야
+calibration / session 시작·종료와 WebSocket 으로 들어오는 EMG 데이터가 일관되게 처리됨)
+"""
+
+from storage.calibration_store import CalibrationSessionStore
+from storage.session_store import SessionStore
+from storage.device_mode_registry import DeviceModeRegistry
+
+calibration_store = CalibrationSessionStore()
+session_store = SessionStore()
+device_mode_registry = DeviceModeRegistry()
+
+__all__ = [
+    "calibration_store",
+    "session_store",
+    "device_mode_registry",
+    "CalibrationSessionStore",
+    "SessionStore",
+    "DeviceModeRegistry",
+]

--- a/storage/calibration_store.py
+++ b/storage/calibration_store.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from schemas.calibration_schema import (
-    CalibrationWindowRequest,
+    CalibrationDataRequest,
     CalibrationResult,
     CalibrationStatus,
     CalibrationStep,
@@ -15,7 +15,7 @@ class CalibrationSession(BaseModel):
     deviceId: str
     status: CalibrationStatus = CalibrationStatus.READY
     currentStep: CalibrationStep = CalibrationStep.REST
-    stepBuffers: Dict[CalibrationStep, List[CalibrationWindowRequest]] = Field(
+    stepBuffers: Dict[CalibrationStep, List[CalibrationDataRequest]] = Field(
         default_factory=lambda: {
             CalibrationStep.REST: [],
             CalibrationStep.LEFT: [],
@@ -28,13 +28,13 @@ class CalibrationSession(BaseModel):
     completedAt: Optional[int] = None
     result: Optional[CalibrationResult] = None
 
-    
+
 class CalibrationSessionStore:
-    #서버 실행되면 sessions 딕셔너리 구조 생성
+    # 서버 실행되면 sessions 딕셔너리 구조 생성
     # {
-    # "CAL-1001": CalibrationSession(...),
-    # "CAL-1002": CalibrationSession(...),
-    # }   
+    #   "CAL-1001": CalibrationSession(...),
+    #   "CAL-1002": CalibrationSession(...),
+    # }
     def __init__(self):
         self._sessions: Dict[str, CalibrationSession] = {}
 
@@ -67,12 +67,12 @@ class CalibrationSessionStore:
     def append_raw_data(
         self,
         calibration_session_id: str,
-        sample: CalibrationWindowRequest,
+        sample: CalibrationDataRequest,
     ) -> Optional[CalibrationSession]:
         session = self.get_session(calibration_session_id)
         if session is None:
             return None
-        
+
         if session.deviceId != sample.deviceId:
             return None
 

--- a/storage/device_mode_registry.py
+++ b/storage/device_mode_registry.py
@@ -1,5 +1,6 @@
+import time
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -16,16 +17,28 @@ class DeviceState(BaseModel):
     # mode 가 CALIBRATION 이면 calibrationSessionId,
     # mode 가 SESSION 이면 sessionId 가 들어감.
     activeId: Optional[str] = None
+    # 마지막 EMG 패킷 도착(또는 모드 전환) 시각, epoch ms.
+    # IDLE 상태에서는 None. lock 누수 방어 sweeper 가 이 값으로 stale 판단.
+    lastActiveAt: Optional[int] = None
 
 
 class DeviceModeRegistry:
     """
-    deviceId 단위로 현재 활성 모드(IDLE / CALIBRATION / SESSION)를 추적.
+    deviceId 단위로 현재 활성 모드(IDLE / CALIBRATION / SESSION) 와
+    마지막 활동 시각을 추적.
 
     - ESP32 한 보드(=deviceId 한 개)는 동시에 calibration 과 session 을 진행할 수 없다.
     - WebSocket 으로 들어온 EMG 패킷은 이 registry 에서 해당 deviceId 의 mode 를
       확인한 뒤 해당 store 로 라우팅 된다.
     - mode 가 IDLE 이면 들어온 EMG 데이터는 무시(drop) 된다.
+
+    Lock 누수 방어:
+    - WebSocket 비정상 종료, ESP32 다운, 사용자가 /end 를 호출 안 한 채로 앱 닫음 등
+      "정상 종료 호출이 빠지는" 모든 케이스에서 _states 가 영원히 점유되어 같은 device 로
+      재시작 못 하는 문제를 막기 위함.
+    - 매 EMG 패킷 도착 시 touch() 가 lastActiveAt 을 갱신.
+    - 백그라운드 sweeper 가 주기적으로 sweep_stale() 을 호출해
+      idle_threshold_ms 초과한 device 를 강제 해제.
     """
 
     def __init__(self):
@@ -52,6 +65,7 @@ class DeviceModeRegistry:
             deviceId=device_id,
             mode=DeviceMode.CALIBRATION,
             activeId=calibration_session_id,
+            lastActiveAt=_now_ms(),
         )
         self._states[device_id] = state
         return state
@@ -67,9 +81,43 @@ class DeviceModeRegistry:
             deviceId=device_id,
             mode=DeviceMode.SESSION,
             activeId=session_id,
+            lastActiveAt=_now_ms(),
         )
         self._states[device_id] = state
         return state
 
+    def touch(self, device_id: str) -> None:
+        """
+        활성 device 의 lastActiveAt 갱신.
+        StreamService 가 IDLE 이 아닌 모든 EMG 패킷에 대해 호출한다.
+        IDLE 이라 _states 에 없는 device 는 no-op.
+        """
+        state = self._states.get(device_id)
+        if state is not None:
+            state.lastActiveAt = _now_ms()
+
     def clear(self, device_id: str) -> None:
         self._states.pop(device_id, None)
+
+    def sweep_stale(self, idle_threshold_ms: int) -> List[str]:
+        """
+        lastActiveAt 이 idle_threshold_ms 보다 오래된 device 의 lock 을 강제 해제.
+        반환값: 청소된 deviceId 목록 (로깅 용도).
+        """
+        now = _now_ms()
+        cleared: List[str] = []
+        # dict 순회 중 mutation 안전을 위해 list() 로 복제
+        for device_id, state in list(self._states.items()):
+            if state.lastActiveAt is None:
+                # 활동 시각이 없는 비정상 상태 → 즉시 정리
+                self._states.pop(device_id, None)
+                cleared.append(device_id)
+                continue
+            if now - state.lastActiveAt > idle_threshold_ms:
+                self._states.pop(device_id, None)
+                cleared.append(device_id)
+        return cleared
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)

--- a/storage/device_mode_registry.py
+++ b/storage/device_mode_registry.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
+from threading import Lock
 
 
 class DeviceMode(str, Enum):
@@ -43,48 +44,57 @@ class DeviceModeRegistry:
 
     def __init__(self):
         self._states: Dict[str, DeviceState] = {}
+        self._lock = Lock()
 
     def get(self, device_id: str) -> DeviceState:
-        return self._states.get(device_id) or DeviceState(deviceId=device_id)
+        with self._lock:
+            return self._states.get(device_id) or DeviceState(deviceId=device_id)
 
     def is_idle(self, device_id: str) -> bool:
-        return self.get(device_id).mode == DeviceMode.IDLE
+        with self._lock:
+            state = self._states.get(device_id) or DeviceState(deviceId=device_id)
+            return state.mode == DeviceMode.IDLE
 
     def set_calibration(
         self,
         device_id: str,
         calibration_session_id: str,
     ) -> DeviceState:
-        current = self.get(device_id)
-        if current.mode != DeviceMode.IDLE:
-            raise ValueError(
-                f"device {device_id} is busy in {current.mode.value} mode "
-                f"(activeId={current.activeId})"
+        
+        with self._lock:
+            current = self._states.get(device_id) or DeviceState(deviceId=device_id)
+
+            if current.mode != DeviceMode.IDLE:
+                raise ValueError(
+                    f"device {device_id} is busy in {current.mode.value} mode "
+                    f"(activeId={current.activeId})"
+                )
+            state = DeviceState(
+                deviceId=device_id,
+                mode=DeviceMode.CALIBRATION,
+                activeId=calibration_session_id,
+                lastActiveAt=_now_ms(),
             )
-        state = DeviceState(
-            deviceId=device_id,
-            mode=DeviceMode.CALIBRATION,
-            activeId=calibration_session_id,
-            lastActiveAt=_now_ms(),
-        )
-        self._states[device_id] = state
-        return state
+            self._states[device_id] = state
+            return state
 
     def set_session(self, device_id: str, session_id: str) -> DeviceState:
-        current = self.get(device_id)
-        if current.mode != DeviceMode.IDLE:
-            raise ValueError(
-                f"device {device_id} is busy in {current.mode.value} mode "
-                f"(activeId={current.activeId})"
+        with self._lock:
+            current = self._states.get(device_id) or DeviceState(deviceId=device_id)
+
+            if current.mode != DeviceMode.IDLE:
+                raise ValueError(
+                    f"device {device_id} is busy in {current.mode.value} mode "
+                    f"(activeId={current.activeId})"
+                )
+            state = DeviceState(
+                deviceId=device_id,
+                mode=DeviceMode.SESSION,
+                activeId=session_id,
+                lastActiveAt=_now_ms(),
             )
-        state = DeviceState(
-            deviceId=device_id,
-            mode=DeviceMode.SESSION,
-            activeId=session_id,
-            lastActiveAt=_now_ms(),
-        )
-        self._states[device_id] = state
-        return state
+            self._states[device_id] = state
+            return state
 
     def touch(self, device_id: str) -> None:
         """
@@ -92,12 +102,14 @@ class DeviceModeRegistry:
         StreamService 가 IDLE 이 아닌 모든 EMG 패킷에 대해 호출한다.
         IDLE 이라 _states 에 없는 device 는 no-op.
         """
-        state = self._states.get(device_id)
-        if state is not None:
-            state.lastActiveAt = _now_ms()
+        with self._lock:
+            state = self._states.get(device_id)
+            if state is not None:
+                state.lastActiveAt = _now_ms()
 
     def clear(self, device_id: str) -> None:
-        self._states.pop(device_id, None)
+        with self._lock:
+            self._states.pop(device_id, None)
 
     def sweep_stale(self, idle_threshold_ms: int) -> List[str]:
         """
@@ -105,18 +117,20 @@ class DeviceModeRegistry:
         반환값: 청소된 deviceId 목록 (로깅 용도).
         """
         now = _now_ms()
-        cleared: List[str] = []
-        # dict 순회 중 mutation 안전을 위해 list() 로 복제
-        for device_id, state in list(self._states.items()):
-            if state.lastActiveAt is None:
-                # 활동 시각이 없는 비정상 상태 → 즉시 정리
+        
+        
+        with self._lock:
+            stale_device_ids = [
+                device_id
+                for device_id, state in self._states.items()
+                if state.lastActiveAt is not None
+                and now - state.lastActiveAt > idle_threshold_ms
+            ]
+
+            for device_id in stale_device_ids:
                 self._states.pop(device_id, None)
-                cleared.append(device_id)
-                continue
-            if now - state.lastActiveAt > idle_threshold_ms:
-                self._states.pop(device_id, None)
-                cleared.append(device_id)
-        return cleared
+
+            return stale_device_ids
 
 
 def _now_ms() -> int:

--- a/storage/device_mode_registry.py
+++ b/storage/device_mode_registry.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+
+class DeviceMode(str, Enum):
+    IDLE = "IDLE"
+    CALIBRATION = "CALIBRATION"
+    SESSION = "SESSION"
+
+
+class DeviceState(BaseModel):
+    deviceId: str
+    mode: DeviceMode = DeviceMode.IDLE
+    # mode 가 CALIBRATION 이면 calibrationSessionId,
+    # mode 가 SESSION 이면 sessionId 가 들어감.
+    activeId: Optional[str] = None
+
+
+class DeviceModeRegistry:
+    """
+    deviceId 단위로 현재 활성 모드(IDLE / CALIBRATION / SESSION)를 추적.
+
+    - ESP32 한 보드(=deviceId 한 개)는 동시에 calibration 과 session 을 진행할 수 없다.
+    - WebSocket 으로 들어온 EMG 패킷은 이 registry 에서 해당 deviceId 의 mode 를
+      확인한 뒤 해당 store 로 라우팅 된다.
+    - mode 가 IDLE 이면 들어온 EMG 데이터는 무시(drop) 된다.
+    """
+
+    def __init__(self):
+        self._states: Dict[str, DeviceState] = {}
+
+    def get(self, device_id: str) -> DeviceState:
+        return self._states.get(device_id) or DeviceState(deviceId=device_id)
+
+    def is_idle(self, device_id: str) -> bool:
+        return self.get(device_id).mode == DeviceMode.IDLE
+
+    def set_calibration(
+        self,
+        device_id: str,
+        calibration_session_id: str,
+    ) -> DeviceState:
+        current = self.get(device_id)
+        if current.mode != DeviceMode.IDLE:
+            raise ValueError(
+                f"device {device_id} is busy in {current.mode.value} mode "
+                f"(activeId={current.activeId})"
+            )
+        state = DeviceState(
+            deviceId=device_id,
+            mode=DeviceMode.CALIBRATION,
+            activeId=calibration_session_id,
+        )
+        self._states[device_id] = state
+        return state
+
+    def set_session(self, device_id: str, session_id: str) -> DeviceState:
+        current = self.get(device_id)
+        if current.mode != DeviceMode.IDLE:
+            raise ValueError(
+                f"device {device_id} is busy in {current.mode.value} mode "
+                f"(activeId={current.activeId})"
+            )
+        state = DeviceState(
+            deviceId=device_id,
+            mode=DeviceMode.SESSION,
+            activeId=session_id,
+        )
+        self._states[device_id] = state
+        return state
+
+    def clear(self, device_id: str) -> None:
+        self._states.pop(device_id, None)

--- a/storage/session_store.py
+++ b/storage/session_store.py
@@ -15,6 +15,7 @@ class Session(BaseModel):
     startedAt: int
     endedAt: Optional[int] = None
     bufferedWindowCount: int = 0
+    lastSequenceNumber: Optional[int] = None
     lastIntent: Optional[str] = None
 
 
@@ -60,4 +61,17 @@ class SessionStore:
 
         session.status = SessionStatus.ENDED
         session.endedAt = ended_at
+        return session
+
+    def increment_window_count(
+        self,
+        session_id: str,
+        sequence_number: int,
+    ) -> Optional[Session]:
+        session = self.get_session(session_id)
+        if session is None:
+            return None
+
+        session.bufferedWindowCount += 1
+        session.lastSequenceNumber = sequence_number
         return session

--- a/storage/session_store.py
+++ b/storage/session_store.py
@@ -1,8 +1,15 @@
-from typing import Dict, Optional
+from collections import deque
+from typing import Deque, Dict, List, Optional
+
 from pydantic import BaseModel
 
-from schemas.session_schema import SessionStatus
+from schemas.session_schema import SessionStatus, SessionWindow
 from schemas.calibration_schema import CalibrationResult
+
+
+# 한 세션이 메모리에 들고 있을 EMG window 의 최대 개수.
+# 추론은 보통 최근 N(=수~수십) window 만 보면 되므로 ring buffer 로 잘라둔다.
+DEFAULT_SESSION_BUFFER_MAXLEN = 200
 
 
 class Session(BaseModel):
@@ -14,25 +21,36 @@ class Session(BaseModel):
     status: SessionStatus = SessionStatus.ACTIVE
     startedAt: int
     endedAt: Optional[int] = None
+    # 누적 카운터(monotonic). 실제 raw window 데이터는 SessionStore._buffers 에 분리 저장.
     bufferedWindowCount: int = 0
     lastSequenceNumber: Optional[int] = None
     lastIntent: Optional[str] = None
 
 
 class SessionStore:
+    """
+    세션 메타데이터(_sessions) 와 raw EMG window ring buffer(_buffers) 를 함께 관리.
+
+    Session pydantic 모델은 API 응답 직렬화에도 쓰이므로 raw EMG 가 들어가지 않도록
+    분리해 두었다. 추론 파이프라인은 get_recent_windows() 로 buffer 를 조회한다.
+    """
+
     # 서버 실행되면 sessions 딕셔너리 구조 생성
     # {
     #   "DRV-2001": Session(...),
     #   "DRV-2002": Session(...),
     # }
-    def __init__(self):
+    def __init__(self, buffer_maxlen: int = DEFAULT_SESSION_BUFFER_MAXLEN):
         self._sessions: Dict[str, Session] = {}
+        self._buffers: Dict[str, Deque[SessionWindow]] = {}
+        self._buffer_maxlen = buffer_maxlen
 
     def exists(self, session_id: str) -> bool:
         return session_id in self._sessions
 
     def create_session(self, session: Session) -> Session:
         self._sessions[session.sessionId] = session
+        self._buffers[session.sessionId] = deque(maxlen=self._buffer_maxlen)
         return session
 
     def get_session(self, session_id: str) -> Optional[Session]:
@@ -61,8 +79,64 @@ class SessionStore:
 
         session.status = SessionStatus.ENDED
         session.endedAt = ended_at
+        # buffer 는 종료 시점에 정리. (메타데이터는 /status 로 조회 가능하도록 남겨둠)
+        self._buffers.pop(session_id, None)
         return session
 
+    def append_window_data(
+        self,
+        session_id: str,
+        window: SessionWindow,
+    ) -> Optional[Session]:
+        """
+        raw EMG window 한 개를 ring buffer 에 적재 + 메타데이터 갱신.
+        SessionService.append_window 의 단일 진입점에서만 호출된다.
+        """
+        session = self.get_session(session_id)
+        if session is None:
+            return None
+
+        buf = self._buffers.get(session_id)
+        if buf is None:
+            return None
+
+        buf.append(window)
+        session.bufferedWindowCount += 1
+        session.lastSequenceNumber = window.sequenceNumber
+        return session
+
+    def get_recent_windows(
+        self,
+        session_id: str,
+        count: int,
+    ) -> List[SessionWindow]:
+        """
+        추론 파이프라인이 최근 N 개 window 를 가져갈 때 호출.
+        buffer 가 없거나 비어있으면 빈 리스트.
+        """
+        buf = self._buffers.get(session_id)
+        if not buf:
+            return []
+        if count <= 0:
+            return []
+        if count >= len(buf):
+            return list(buf)
+        return list(buf)[-count:]
+
+    def update_last_intent(
+        self,
+        session_id: str,
+        intent: str,
+    ) -> Optional[Session]:
+        session = self.get_session(session_id)
+        if session is None:
+            return None
+
+        session.lastIntent = intent
+        return session
+
+    # ----- 하위 호환 -----
+    # 아직 데이터 없이 카운트만 바꾸고 싶은 경로용. 신규 코드는 append_window_data 사용 권장.
     def increment_window_count(
         self,
         session_id: str,


### PR DESCRIPTION
## 개요

ESP32 EMG 보드는 한 개이고 데이터는 실시간으로 한 스트림으로 들어오는데,
기존 구조는 calibration 만 REST 로 분리되어 있어서 같은 데이터를 두 경로로
처리해야 하는 모순이 있었음. (게다가 `services/stream_service.py` 가 비어 있어
WS 핸들러 자체가 import 단계에서 깨져 있었음.)

→ WebSocket 단일 채널로 통합하고, calibration / session 라우팅은 서버가
   deviceId 기준으로 결정하도록 변경.

## 핵심 변경

- **DeviceModeRegistry 신규** (`storage/device_mode_registry.py`)
  - `deviceId → (IDLE / CALIBRATION / SESSION, activeId)` 추적
  - 한 device 가 동시에 두 모드에 들어가지 못하도록 `set_*` 단계에서 강제
- **WS 메시지 스키마 단일화** (`schemas/stream_schema.py`)
  - 기존 `type` 기반 `CalibrationWSRequest` / `DrivingWSRequest` 제거
  - 단일 `EmgWindowMessage` + `EmgWindowAck` 로 통합
- **StreamService 구현** (`services/stream_service.py`)
  - registry mode 에 따라 calibration_store / session_store 로 라우팅
  - IDLE 이면 drop (요건: 진행 중 아닐 때 EMG 무시)
- **calibration / session service 에 registry 연동**
  - `start_calibration` / `start_session` 시 mode set, 이미 다른 모드면 거절
  - `finish_calibration` / `end_session` 시 mode clear → IDLE 복귀
- **싱글톤 store hub** (`storage/__init__.py`)
  - 라우터별 store 중복 생성 제거, 모든 라우터가 같은 인스턴스 공유
- **routers 정리**
  - stream_router: 단일 메시지 핸들러로 단순화
  - calibration_router / session_router: 싱글톤 import 사용

추론 트리거 위치는 `services/stream_service.py` 내부에 TODO 주석으로 표시.

## ESP32 가 보낼 새 메시지 형식

```json
{
  "deviceId": "esp32-A",
  "sequenceNumber": 123,
  "timestamp": 1730000000000,
  "samplingRate": 1000,
  "windowSize": 200,
  "channels": [
    {"channelIndex": 0, "samples": [/* ... */]},
    {"channelIndex": 1, "samples": [/* ... */]},
    {"channelIndex": 2, "samples": [/* ... */]}
  ]
}
```

서버 ack:
```json
{
  "type": "emg_window_ack",
  "success": true,
  "message": "calibration window appended",
  "data": {
    "deviceId": "esp32-A",
    "mode": "CALIBRATION",
    "activeId": "CAL-1",
    "acceptedSequenceNumber": 123,
    "bufferedWindowCount": 7
  }
}
```

## 동작 흐름
ESP32 ─ /ai/stream/ws ─▶ StreamService
 │
├─  IDLE         → drop (요건 4)
├─ CALIBRATION  → CalibrationService.append_calibration_data
└─ SESSION      → SessionService.append_window

StreamService 는 store 를 직접 호출하지 않는다. 도메인 검증 로직은 모두 SessionService / CalibrationService 안에서 일어나고, StreamService 는
- DeviceMode 라우팅
- 패킷 → 도메인 request 변환
- 활성 device 의 lastActiveAt 갱신 (lock 누수 방어)
- 도메인 ValueError → ack 변환
네 가지만 담당한다.

## Test plan

- [x] `python -m uvicorn main:app --reload` 정상 기동
- [ ] `/ai/calibration/start` 후 같은 deviceId 로 `/ai/sessions/start` → 400
- [x] WS 연결 후 calibration 시작 전 EMG 송출 → ack `mode=IDLE` (drop)
- [ ] calibration 진행 중 EMG → `mode=CALIBRATION` ack, stepBuffers 누적
- [ ] `/ai/calibration/finish` 후 EMG → 다시 `mode=IDLE` (drop)
- [ ] `/ai/sessions/start` 후 EMG → `mode=SESSION` ack, bufferedWindowCount 증가
- [ ] `/ai/sessions/end` 후 EMG → `mode=IDLE` (drop)
- [ ] sequenceNumber 가 단조 증가하지 않으면 ack `success=false`

## 관련 이슈
close #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified EMG window message handling with a single validated input and standardized acknowledgement payloads
  * Central device-mode registry with shared in-memory singletons and a new stream/service layer for EMG routing
  * Per-session window buffering and recent-window retrieval; app-level background sweeper for stale device locks

* **Improvements**
  * Consistent WebSocket error/success responses, stricter validation, sequence-number checks, and buffered-window counting
  * Device mode transitions now reserved/released during calibration and session lifecycles

* **Chores**
  * Updated .gitignore to ignore Python artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->